### PR TITLE
Drop Python 3.5 support

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -51,7 +51,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
-        python: [3.5, 3.6, 3.7, 3.8]
+        python: [3.6, 3.7, 3.8]
         include:
           - os: ubuntu-latest
             os_name: Linux

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -7,7 +7,7 @@ repos:
     rev: v1.25.2
     hooks:
       - id: pyupgrade
-        args: [--py3-plus]
+        args: [--py36-plus]
   - repo: https://github.com/asottile/seed-isort-config
     rev: v1.9.3
     hooks:

--- a/jekyllnb/exporter.py
+++ b/jekyllnb/exporter.py
@@ -10,7 +10,7 @@ from traitlets.config import Config
 class JekyllExporter(MarkdownExporter):
     """Exporter to write Markdown with Jekyll metadata"""
 
-    resources = {}  # type: Dict[str, Any]
+    resources: Dict[str, Any] = {}
 
     def from_filename(self, filename, resources=None, **kwargs):
         """Convert notebook from a file

--- a/jekyllnb/jekyllnb.py
+++ b/jekyllnb/jekyllnb.py
@@ -7,7 +7,7 @@ from traitlets.config import catch_config_error
 
 from .__version__ import __version__
 
-JEKYLLNB_ALIASES = {}  # type: Dict[str, str]
+JEKYLLNB_ALIASES: Dict[str, str] = {}
 JEKYLLNB_ALIASES.update(nbconvert_aliases)
 JEKYLLNB_ALIASES.update(
     {
@@ -17,7 +17,7 @@ JEKYLLNB_ALIASES.update(
     }
 )
 
-JEKYLLNB_FLAGS = {}  # type: Dict[str, Sequence[Any]]
+JEKYLLNB_FLAGS: Dict[str, Sequence[Any]] = {}
 JEKYLLNB_FLAGS.update(nbconvert_flags)
 JEKYLLNB_FLAGS.update(
     {

--- a/jekyllnb/jekyllnb.py
+++ b/jekyllnb/jekyllnb.py
@@ -55,9 +55,7 @@ class JekyllNB(NbConvertApp):
 
         if change["new"].lower() != default_format:
             raise ValueError(
-                "Invalid export format {}, value must be {}".format(
-                    change["new"], default_format
-                )
+                f"Invalid export format {change['new']}, value must be {default_format}"
             )
 
     @catch_config_error

--- a/poetry.lock
+++ b/poetry.lock
@@ -306,18 +306,6 @@ version = "1.4.2"
 
 [[package]]
 category = "dev"
-description = "Object-oriented filesystem paths"
-marker = "python_version < \"3.6\""
-name = "pathlib2"
-optional = false
-python-versions = "*"
-version = "2.3.5"
-
-[package.dependencies]
-six = "*"
-
-[[package]]
-category = "dev"
 description = "plugin and hook calling mechanisms for python"
 name = "pluggy"
 optional = false
@@ -414,10 +402,6 @@ wcwidth = "*"
 [package.dependencies.importlib-metadata]
 python = "<3.8"
 version = ">=0.12"
-
-[package.dependencies.pathlib2]
-python = "<3.6"
-version = ">=2.2.0"
 
 [package.extras]
 testing = ["argcomplete", "hypothesis (>=3.56)", "mock", "nose", "requests", "xmlschema"]
@@ -600,8 +584,8 @@ docs = ["sphinx", "jaraco.packaging (>=3.2)", "rst.linker (>=1.9)"]
 testing = ["pathlib2", "contextlib2", "unittest2"]
 
 [metadata]
-content-hash = "1cfc8e4d9cf7c87a9e7cc327e9b2059c1ccd6d76573716016bd21f4b39c97f52"
-python-versions = "^3.5"
+content-hash = "7bb8f56180a679b58cb9311331b24d024fdd1f4ea38c3882193ada3eb906f50b"
+python-versions = "^3.6"
 
 [metadata.files]
 "aspy.yaml" = [
@@ -764,10 +748,6 @@ packaging = [
 ]
 pandocfilters = [
     {file = "pandocfilters-1.4.2.tar.gz", hash = "sha256:b3dd70e169bb5449e6bc6ff96aea89c5eea8c5f6ab5e207fc2f521a2cf4a0da9"},
-]
-pathlib2 = [
-    {file = "pathlib2-2.3.5-py2.py3-none-any.whl", hash = "sha256:0ec8205a157c80d7acc301c0b18fbd5d44fe655968f5d947b6ecef5290fc35db"},
-    {file = "pathlib2-2.3.5.tar.gz", hash = "sha256:6cd9a47b597b37cc57de1c05e56fb1a1c9cc9fab04fe78c29acd090418529868"},
 ]
 pluggy = [
     {file = "pluggy-0.13.1-py2.py3-none-any.whl", hash = "sha256:966c145cd83c96502c3c3868f50408687b38434af77734af1e9ca461a4081d2d"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,7 +16,7 @@ classifiers = [
 ]
 
 [tool.poetry.dependencies]
-python = "^3.5"
+python = "^3.6"
 nbconvert = "^5.6.1"
 
 [tool.poetry.dev-dependencies]


### PR DESCRIPTION
Permits variable static types in code instead of comments.